### PR TITLE
v1.5.0

### DIFF
--- a/__tests__/DiviConfigParser.spec.ts
+++ b/__tests__/DiviConfigParser.spec.ts
@@ -117,6 +117,18 @@ describe('Divi Config Parser', () => {
 		);
 	});
 
+	test('Cli Flag string creation', () => {
+		const diviConfig = new DiviConfigParser();
+
+		const flagName = randomString();
+
+		const content = randomString();
+
+		expect(diviConfig.cliFlagToString<any>(flagName, content)).toEqual(
+			'-' + flagName + '=' + content
+		);
+	});
+
 	test('Sets flags from divi config file', () => {
 		const diviConfig = new DiviConfigParser();
 

--- a/__tests__/DiviConfigParser.spec.ts
+++ b/__tests__/DiviConfigParser.spec.ts
@@ -105,6 +105,18 @@ describe('Divi Config Parser', () => {
 		);
 	});
 
+	test('Flag string creation', () => {
+		const diviConfig = new DiviConfigParser();
+
+		const flagName = randomString();
+
+		const content = randomString();
+
+		expect(diviConfig.flagToString<any>(flagName, content)).toEqual(
+			flagName + '=' + content
+		);
+	});
+
 	test('Sets flags from divi config file', () => {
 		const diviConfig = new DiviConfigParser();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "diviconfigparser",
-	"version": "1.3.1",
+	"version": "1.5.0",
 	"description": "Parse and manipulate a divi.conf and convert back to a string",
 	"main": "build/index",
 	"scripts": {

--- a/src/DiviConfigParser.ts
+++ b/src/DiviConfigParser.ts
@@ -78,6 +78,10 @@ export default class DiviConfigParser {
 		return flag + '=' + value.toString();
 	}
 
+	cliFlagToString<F extends FlagName>(flag: F, value: FlagTypes[F]): string {
+		return '-' + this.flagToString(flag, value);
+	}
+
 	private flagWithMultipleValuesToString(
 		flag: FlagName,
 		values: string[]

--- a/src/DiviConfigParser.ts
+++ b/src/DiviConfigParser.ts
@@ -70,15 +70,12 @@ export default class DiviConfigParser {
 		}
 	}
 
-	private flagValuePairToString(
-		flag: FlagName,
-		value: FlagTypes[FlagName]
-	): string {
+	flagToString<F extends FlagName>(flag: F, value: FlagTypes[F]): string {
 		if (typeof value === 'undefined') {
 			console.warn('unable to parse value:', value, 'for flag:', flag);
 			return;
 		}
-		return flag + '=' + value.toString() + '\n';
+		return flag + '=' + value.toString();
 	}
 
 	private flagWithMultipleValuesToString(
@@ -87,7 +84,7 @@ export default class DiviConfigParser {
 	): string {
 		let result = '';
 		for (const value of values) {
-			result += this.flagValuePairToString(flag, value);
+			result += this.flagToString(flag, value) + '\n';
 		}
 		return result;
 	}
@@ -104,10 +101,8 @@ export default class DiviConfigParser {
 					flagContents
 				);
 			} else {
-				diviConfigString += this.flagValuePairToString(
-					flag as FlagName,
-					flagContents
-				);
+				diviConfigString +=
+					this.flagToString(flag as FlagName, flagContents) + '\n';
 			}
 		}
 

--- a/src/FlagNames.ts
+++ b/src/FlagNames.ts
@@ -22,6 +22,7 @@ export declare interface FlagTypes {
 	stakesplitthreshold: number;
 	override_mnpayee: 0 | 1;
 	regtest: 0 | 1;
+	datadir: string;
 }
 
 export declare type FlagName = keyof FlagTypes;


### PR DESCRIPTION
- `datadir=<string>` flag
- Cli flags for configuring daemon on start (./divid `-cliFlag=example`)